### PR TITLE
Fix byte compilation

### DIFF
--- a/eboy-cpu.el
+++ b/eboy-cpu.el
@@ -3,6 +3,7 @@
 ;;; Commentary:
 ;;; Code:
 ;;(require 'eboy)
+(eval-when-compile (require 'cl))
 (require 'eboy-macros)
 
 (defvar eboy-cpu nil "All the cpu instruction functions.")

--- a/eboy-cpu.el
+++ b/eboy-cpu.el
@@ -3,6 +3,7 @@
 ;;; Commentary:
 ;;; Code:
 ;;(require 'eboy)
+(require 'eboy-macros)
 
 (defvar eboy-cpu nil "All the cpu instruction functions.")
 (defvar eboy-cpu-cb nil "All the CB opcode cpu instruction functions.")

--- a/eboy-cpu.el
+++ b/eboy-cpu.el
@@ -83,7 +83,7 @@
            (eboy-set-flag eboy-flags :H nil))
          (incf eboy-clock-cycles 4))
        (lambda nil "0x10 STOP -/- 10 "
-         (setq eboy-halted t)
+         (setq eboy-cpu-halted t)
          (incf eboy-clock-cycles 4))
        (lambda nil "0x11 LD DE, $%04x"
          (eboy-set-rDE (eboy-get-short))
@@ -484,7 +484,7 @@
          (eboy-mem-write-byte (eboy-get-rHL) eboy-rL)
          (incf eboy-clock-cycles 8))
        (lambda nil "0x76 HALT -/- "
-         (setq eboy-halted t)
+         (setq eboy-cpu-halted t)
          (incf eboy-clock-cycles 4))
        (lambda nil "0x77 LD (HL),A"
          (eboy-mem-write-byte (eboy-get-rHL) eboy-rA)

--- a/eboy-macros.el
+++ b/eboy-macros.el
@@ -1,0 +1,30 @@
+(defmacro eboy-add-byte (byte value)
+  "Simulate byte behavior: add VALUE to BYTE."
+  `(progn (setq ,byte (+ ,byte ,value))
+          (setq ,byte (logand ,byte #xFF))))
+
+(defmacro eboy-add-to-short (short value)
+  "Simulate short behavior: add VALUE to SHORT."
+  `(progn (setq ,short (+ ,short ,value))
+          (setq ,short (logand ,short #xFFFF))))
+
+(defmacro eboy-dec (reg flags)
+  "CPU Instruction: Decrement register REG and update FLAGS."
+  `(progn (eboy-add-byte ,reg -1)
+          (eboy-set-flag ,flags ,:Z (= ,reg 0))
+          (eboy-set-flag ,flags ,:N t)
+          (eboy-set-flag ,flags ,:H (= (logand ,reg #xF) #xF))))
+
+(defmacro eboy-inc-rpair (r1 r2 value)
+  "Increase register pair R1 R2 with VALUE."
+  `(let ((rpair (eboy-get-rpair ,r1 ,r2)) )
+     (eboy-add-to-short rpair ,value)
+     (eboy-set-rpair ,r1 ,r2 rpair)))
+
+(defmacro eboy-set-rpair (r1 r2 value)
+  "Put VALUE into register pair R1 and R2."
+  `(progn
+    (setq ,r1 (logand (lsh ,value -8) #xff))
+    (setq ,r2 (logand ,value #xff))))
+
+(provide 'eboy-macros)

--- a/eboy.el
+++ b/eboy.el
@@ -33,6 +33,7 @@
 
 
 ;;; Code:
+(require 'eboy-macros)
 ;;(load "eboy-cpu.el")
 (require 'eboy-cpu)
 
@@ -109,41 +110,12 @@
 (defvar eboy-joypad-direction-keys #xF "The direction keys of the joypad, |Down|Up|Left|Right| (0=pressed).")
 (defvar eboy-joypad-button-keys #xF "The button keys of the joypad, |Start|Select|B|A| (0=pressed).")
 
-(defmacro eboy-add-byte (byte value)
-  "Simulate byte behavior: add VALUE to BYTE."
-  `(progn (setq ,byte (+ ,byte ,value))
-          (setq ,byte (logand ,byte #xFF))))
-
-(defmacro eboy-add-to-short (short value)
-  "Simulate short behavior: add VALUE to SHORT."
-  `(progn (setq ,short (+ ,short ,value))
-          (setq ,short (logand ,short #xFFFF))))
-
 (defun eboy-byte-to-signed (byte)
   "Convert BYTE to signed number."
   ;;(* (1+ (logxor byte #xFF)) -1)
   (if (not (zerop (logand #x80 byte)))
       (setq byte (- byte #x100)))
   byte)
-
-(defmacro eboy-dec (reg flags)
-  "CPU Instruction: Decrement register REG and update FLAGS."
-  `(progn (eboy-add-byte ,reg -1)
-          (eboy-set-flag ,flags ,:Z (= ,reg 0))
-          (eboy-set-flag ,flags ,:N t)
-          (eboy-set-flag ,flags ,:H (= (logand ,reg #xF) #xF))))
-
-(defmacro eboy-inc-rpair (r1 r2 value)
-  "Increase register pair R1 R2 with VALUE."
-  `(let ((rpair (eboy-get-rpair ,r1 ,r2)) )
-     (eboy-add-to-short rpair ,value)
-     (eboy-set-rpair ,r1 ,r2 rpair)))
-
-(defmacro eboy-set-rpair (r1 r2 value)
-  "Put VALUE into register pair R1 and R2."
-  `(progn
-    (setq ,r1 (logand (lsh ,value -8) #xff))
-    (setq ,r2 (logand ,value #xff))))
 
 (defun eboy-get-rpair (r1 r2)
   "Get short by combining byte register R1 and R2."


### PR DESCRIPTION
To ensure the emulator is running at the highest possible speed, I've tried byte-compiling it, but it failed with many warnings and an error at runtime. This PR resolves these issues